### PR TITLE
Add sensitivity as matched filter amplitudes for TFM imaging.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,19 +35,19 @@ Features currently include:
         :link: user_install
         :link-type: ref
 
-        Install arim
+        Instructions for installation
 		
     .. grid-item-card:: User Guide
         :link: user_guide
         :link-type: ref
 
-        In-depth information on key concepts in arim
+        In-depth overview & bibliography for key concepts
 
     .. grid-item-card:: API reference
         :link: api
         :link-type: ref
 
-        The reference guide for the arim API.
+        Reference guide for the arim API
 		
     .. grid-item-card:: Development
         :link: dev_install

--- a/docs/source/installation/development.rst
+++ b/docs/source/installation/development.rst
@@ -140,8 +140,8 @@ compiles by building a version locally:
 
 The output will be found in ``docs/_build/html``.
 
-To compile documentation using Github in a forked repository, add a secret in your Github repository. Under the repository
-settings, go to ``Security -> Secrets and variables -> Actions``, and under ``Repository secrets`` click ``New repository secret``.
+To compile documentation using Github in a forked repository, add a variable to your Github repository. Under the repository
+settings, go to ``Security -> Secrets and variables -> Actions``. In the ``Variables`` tab, under ``Repository secrets`` click ``New repository variable``.
 Set ``COMPILE_DOCUMENTATION`` to ``true``.
 
 If working in a different branch to ``master``, edit the branches specified in ``.github/workflows/arim_docs.yml`` to

--- a/docs/source/user/bibliography.rst
+++ b/docs/source/user/bibliography.rst
@@ -7,13 +7,61 @@ Bibliography
 ..
   Put citations here.
 
-  Example of citation: [Holmes2005]_
+  Example of citation: [Holmes]_
+  
 
+.. [Brind] Brind, R. J., J. D. Achenbach, and J. E. Gubernatis. 1984.
+		"High-Frequency Scattering of Elastic Waves from Cylindrical Cavities".
+		Wave Motion 6 (1): 41–60. doi:10.1016/0165-2125(84)90022-2.
 
-.. [Holmes2005] Holmes, Caroline, Bruce W. Drinkwater, and Paul D. Wilcox. 2005. ‘Post-Processing of the Full Matrix of Ultrasonic Transmit–receive Array Data for Non-Destructive Evaluation’. NDT & E International 38 (8): 701–11. doi:10.1016/j.ndteint.2005.04.002.
+.. [Drinkwater] Drinkwater, Bruce W., and Paul D. Wilcox. 2006.
+		"Ultrasonic Arrays for Non-Destructive Evaluation: A Review".
+		NDT & E International 39 (7): 525–41. doi:10.1016/j.ndteint.2006.03.006.
+
+.. [Freund98] Freund, L. B. 1998.
+		`Dynamic Fracture Mechanics`.
+		Cambridge University Press. p. 83. ISBN 978-0521629225.
+
+.. [Glushkov] Glushkov, Evgeny, Natalia Glushkova, Alexander Ekhlakov, and Elena Shapar. 2006.
+		"An Analytically Based Computer Model for Surface Measurements in Ultrasonic Crack Detection".
+		Wave Motion 43 (6): 458–73. doi:10.1016/j.wavemoti.2006.03.002.
+
+.. [Holmes] Holmes, Caroline, Bruce W. Drinkwater, and Paul D. Wilcox. 2005.
+		"Post-Processing of the Full Matrix of Ultrasonic Transmit–receive Array Data for Non-Destructive Evaluation".
+		NDT & E International 38 (8): 701–11. doi:10.1016/j.ndteint.2005.04.002.
 
 .. [KK] Krautkrämer, Joseph, and Herbert Krautkrämer. 1990.
-        Ultrasonic Testing of Materials. 4th, 1990 ed.
-        Springer-Verlag Berlin Heidelberg. http://link.springer.com/book/10.1007/978-3-662-10680-8.
+        `Ultrasonic Testing of Materials`. 4th, 1990 ed.
+        Springer-Verlag Berlin Heidelberg. doi:10.1007/978-3-662-10680-8.
 
-.. [Schmerr] Schmerr, Lester W. 2016. Fundamentals of Ultrasonic Nondestructive Evaluation: A Modeling Approach. 2nd ed. 2016 edition. New York, NY: Springer.
+.. [Lopez-Sanchez] Lopez-Sanchez, Ana L., Hak-Joon Kim, Lester W. Schmerr, and Alexander Sedov. 2005.
+		"Measurement Models and Scattering Models for Predicting the Ultrasonic Pulse-Echo Response From Side-Drilled Holes".
+		Journal of Nondestructive Evaluation 24 3): 83–96. doi:10.1007/s10921-005-7658-4.
+
+.. [Miller] Miller, G. F., and H. Pursey. 1954.
+		"The Field and Radiation Impedance of Mechanical Radiators on the Free Surface of a Semi-Infinite Isotropic Solid".
+		Proceedings of the Royal Society of London A: Mathematical, Physical and Engineering Sciences 223 (1155): 521–41. doi:10.1098/rspa.1954.0134.
+
+.. [Ogilvy83] Ogilvy, J. A., and J. A. G. Temple. 1983.
+		"Diffraction of Elastic Waves by Cracks: Application to Time-of-Flight Inspection".
+		Ultrasonics 21 (6):259–69. doi:10.1016/0041-624X(83)90058-6.
+
+.. [Schmerr] Schmerr, Lester W. 2016.
+		`Fundamentals of Ultrasonic Nondestructive Evaluation: A Modeling Approach`.
+		2nd ed. New York, NY: Springer. doi:10.1007/978-3-319-30463-2
+
+.. [SchmerrArrays] Schmerr, Lester W. 2015.
+		`Fundamentals of Ultrasonic Phased Arrays`.
+		New York, NY: Springer.
+
+.. [Turin] Turin, George L. 1960.
+		"An introduction to matched filters".
+		IEEE Transactions on Information Theory 6 (3): 311-29. doi:10.1109/TIT.1960.1057571
+
+.. [Wooh] Wooh, Shi-Chang, and Yijun Shi. 1999.
+		"Three-Dimensional Beam Directivity of Phase-Steered Ultrasound".
+		The Journal of the Acoustical Society of America 105 (6): 3275–82. doi:10.1121/1.424655.
+
+.. [Zhang] Zhang, Jie, B.W. Drinkwater, and P.D. Wilcox. 2008.
+		"Defect Characterization Using an Ultrasonic Array to Measure the Scattering Coefficient Matrix".
+		IEEE Transactions on Ultrasonics, Ferroelectrics, and Frequency Control 55 (10): 2254–65. doi:10.1109/TUFFC.924.

--- a/docs/source/user/im/tfm.rst
+++ b/docs/source/user/im/tfm.rst
@@ -6,7 +6,7 @@ Total focusing method
 
 .. py:currentmodule:: arim.im.tfm
 
-Original paper on TFM: [Holmes2005]_
+Original paper on TFM: [Holmes]_
 
 Related modules:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = []
 authors = [
   { name = "Nicolas Budyn", email = "contact@budyn.dev" },
   { name = "Rhodri Bevan", email = "" },
-  { name = "Matt Chandler", email = "m.chandler@bristol.ac.uk"},
+  { name = "Matt Chandler", email = "matt@mgchandler.com"},
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -46,7 +46,7 @@ docs = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/ndtatbristol/arim#readme"
+Documentation = "https://ndtatbristol.github.io/arim"
 Issues = "https://github.com/ndtatbristol/arim/issues"
 Source = "https://github.com/ndtatbristol/arim"
 

--- a/src/arim/__init__.py
+++ b/src/arim/__init__.py
@@ -78,4 +78,4 @@ __all__ = [
 #  https://www.python.org/dev/peps/pep-0440/
 #  https://semver.org/
 # Must be bumped at each release
-__version__ = "0.10.0.a0"
+__version__ = "0.10.0.rc1"

--- a/src/arim/core.py
+++ b/src/arim/core.py
@@ -58,12 +58,15 @@ def material_attenuation_factory(kind, *args, **kwargs):
     Examples
     --------
     Constant material attenuation:
+
     >>> mat_att_func = material_attenuation_factory("constant", 15.)
 
     Polynomial material attenuation ``(1 + 2*(frequency/1e6) + 3*(frequency/1e6)**2)``
+
     >>> mat_att_func = material_attenuation_factory("polynomial", (1, 2, 3))
 
     To use:
+
     >>> frequency = 5e6
     >>> mat_att_func(frequency)
 
@@ -95,12 +98,12 @@ class Frame:
 
     Parameters
     ----------
-    timetraces
-    tx
-    rx
-    probe
-    examination_object
-    metadata
+    timetraces : ndarray
+    tx : ndarray
+    rx : ndarray
+    probe : Probe
+    examination_object : ExaminationObject
+    metadata : dict
 
     Attributes
     ----------
@@ -200,11 +203,11 @@ class Frame:
 
         Parameters
         ----------
-        filt: Filter
+        filt : Filter
 
         Returns
         -------
-        frame: Frame
+        frame : Frame
             New Frame object where the timetraces are filtered. All objects are passed
             by reference.
 
@@ -313,6 +316,7 @@ class Frame:
         Returns
         -------
         bool
+
         """
         orig_pairs = {(tx, rx) for tx, rx in zip(self.tx, self.rx)}
         reciprocal_pairs = {(rx, tx) for tx, rx in zip(self.tx, self.rx)}
@@ -340,6 +344,7 @@ class Frame:
         The new Frame shares the time, probe, examination object and metadata as the original
         one, and may or may not share the same timetraces, tx and rx depending on the kind of
         indexing.
+
         """
         timetraces = self.timetraces[timetraces_idx]
         tx = self.tx[timetraces_idx]
@@ -476,7 +481,6 @@ class Probe:
         Probe coordinate system.
     metadata : dict
 
-
     """
 
     __slots__ = [
@@ -578,14 +582,26 @@ class Probe:
         Populate the following keys in internal dictionary `metadata` if they not exist: numx, pitch_x, numy,
         pitch_y, probe_type ('single', 'linear' or 'matrix').
 
+        Parameters
+        ----------
 
-        :param numx: number of elements along x axis
-        :param pitch_x: difference between two consecutive elements along x axis (either positive or negative)
-        :param numy: number of elements along y axis
-        :param pitch_y: difference between two consecutive elements along y axis (either positive or negative)
-        :param args: positional arguments passed to Probe.__init__
-        :param kwargs: keywords arguments passed to Probe.__init__
-        :return: Probe
+        numx : int
+            Number of elements along x axis
+        pitch_x : float
+            Difference between two consecutive elements along x axis (either positive or negative)
+        numy : int
+            Number of elements along y axis
+        pitch_y : float
+            Difference between two consecutive elements along y axis (either positive or negative)
+        args
+            Positional arguments passed to `Probe.__init__`
+        kwargs
+            Keyword arguments passed to `Probe.__init__`
+
+        Returns
+        -------
+        Probe
+
         """
         numx = int(numx)
         numy = int(numy)
@@ -977,6 +993,7 @@ class Interface:
     are_normals_on_out_rays_side : bool or None
         Are the normals of the interface pointing towards the outgoing rays? True or False.
         If not relevant (no outgoing rays): None.
+
     """
 
     def __init__(
@@ -1109,7 +1126,6 @@ class Path:
 
         numlegs = nummodes = numinterfaces - 1
 
-
     Parameters
     ----------
     interfaces : tuple of Interface
@@ -1138,6 +1154,7 @@ class Path:
         Results of ray tracing.
     name : str or None
         Name (optional)
+
     """
 
     def __init__(self, interfaces, materials, modes, name=None):
@@ -1257,8 +1274,10 @@ class Material:
 
     Examples
     --------
-        >>> alu = Material(6300., 3120., 2700., 'solid', metadata={'long_name': 'Aluminium'})
-        >>> water = Material(1480., None, 1000., 'liquid', metadata={'long_name': 'Water'})
+
+    >>> alu = Material(6300., 3120., 2700., 'solid', metadata={'long_name': 'Aluminium'})
+    >>> water = Material(1480., None, 1000., 'liquid', metadata={'long_name': 'Water'})
+
     """
 
     def __init__(
@@ -1319,6 +1338,7 @@ class Material:
 
         Examples
         --------
+
         >>> material.velocity('L')
         # this return material.longitudinal_vel
 
@@ -1345,6 +1365,7 @@ class Material:
 
         Examples
         --------
+
         >>> material.attenuation('L')
 
         """
@@ -1444,7 +1465,8 @@ class BlockInContact(ExaminationObject):
 
 
 class Time:
-    """Linearly spaced time vector.
+    """
+    Linearly spaced time vector.
 
     Parameters
     ----------
@@ -1515,7 +1537,8 @@ class Time:
 
     @classmethod
     def from_vect(cls, timevect, rtol=1e-2):
-        """Construct a time object from a linearly spaced time vector.
+        """
+        Construct a time object from a linearly spaced time vector.
         Check that the vector is linearly spaced (tolerance: all steps must be within
         ± 1e-3 times the average step).
 

--- a/src/arim/geometry.py
+++ b/src/arim/geometry.py
@@ -282,6 +282,7 @@ class Points:
         Returns
         -------
         translated_points : Points
+
         """
         new_coords = self.coords + direction
         translated_points = self.__class__(new_coords, self.name)
@@ -407,7 +408,6 @@ class CoordinateSystem:
     coordinate system to be consistent with MFMC terminology (global and probe coordinate systems)
     and to avoid confusion with the word "frame" as a set of timetrace.
 
-
     Attributes
     ----------
     origin
@@ -417,6 +417,7 @@ class CoordinateSystem:
     basis_matrix : ndarray
         i_hat, j_hat and k_hat stored in columns ('matrice de passage' de la base locale vers GCS).
         TODO: different convention as stated in header of the file
+
     """
 
     __slots__ = ["_origin", "_i_hat", "_j_hat"]
@@ -492,6 +493,7 @@ class CoordinateSystem:
         See Also
         --------
         :func:`convert_to_gcs`
+
         """
         points = points_gcs.translate(-self.origin)
         # TODO: improve convert_from_gcs
@@ -524,6 +526,7 @@ class CoordinateSystem:
         Notes
         -----
         This function is used to express a set of points relatively to a set of probe elements.
+
         """
         # The rotation of the points is likely to be the longest operation. Do it only once.
         points_cs = self.convert_from_gcs(points_gcs)
@@ -554,6 +557,7 @@ class CoordinateSystem:
         See Also
         --------
         :func:`convert_from_gcs`
+
         """
         points_cs = points_cs.coords
 
@@ -573,6 +577,7 @@ class CoordinateSystem:
         -------
         cs
             New coordinate system.
+
         """
         old_origin = Points(self.origin)
         new_origin = old_origin.translate(vector)[()]
@@ -591,6 +596,7 @@ class CoordinateSystem:
         -------
         cs
             New coordinate system.
+
         """
         old_basis = np.stack(
             (self.origin, self.origin + self.i_hat, self.origin + self.j_hat), axis=0
@@ -1073,6 +1079,7 @@ def rotate(coords, rotation_matrix, centre=None):
     -------
     rotated_points : ndarray
         Shape: (\*shape_points, 3
+
     """
     assert rotation_matrix.shape[-2:] == (3, 3)
 
@@ -1111,6 +1118,7 @@ def to_gcs(coords_cs, bases, origins):
     -------
     coords_gcs : ndarray
         Shape: (\*shape_points, 3)
+
     """
     # OM' = Origin + OM_x * i_hat + OM_y * j_hat + OM_z * k_hat
     return np.einsum("...ij,...i->...j", bases, coords_cs) + origins
@@ -1139,6 +1147,7 @@ def from_gcs(points_gcs, bases, origins):
     -------
     coords_gcs : ndarray
         Shape: (\*shape_points, 3)
+
     """
     return np.einsum("...ji,...i->...j", bases, points_gcs - origins)
 
@@ -1171,6 +1180,7 @@ def are_points_close(points1, points2, atol=1e-8, rtol=0.0):
     Returns
     -------
     bool
+
     """
     return len(points1.shape) == len(points2.shape) and np.allclose(
         points1.coords, points2.coords, rtol=rtol, atol=atol
@@ -1230,6 +1240,8 @@ def norm2(x, y, z, out=None):
 
     Returns
     -------
+    out : ndarray
+        If `out` was provided, a reference to it is returned.
 
     """
     if out is None:
@@ -1254,6 +1266,8 @@ def norm2_2d(x, y, out=None):
 
     Returns
     -------
+    out : ndarray
+        If `out` was provided, a reference to it is returned.
 
     """
     if out is None:
@@ -1412,6 +1426,7 @@ def distance_pairwise(
     -------
     distance : ndarray [num1 x num2]
         Euclidean distances between the points of the two input sets.
+
     """
     # Check dimensions and shapes
     try:
@@ -1486,6 +1501,7 @@ def is_orthonormal_direct(basis):
 
     Returns
     -------
+    bool
 
     """
     return is_orthonormal(basis) and np.allclose(
@@ -1545,8 +1561,9 @@ def points_in_rectbox(
     Examples
     --------
 
+    Return points such as ``10 <= x`` and ``y <= 20`` and ``30 <= z <= zmax``.
+
     >>> points_in_rectbox(x, y, z, xmin=10, ymax=20, zmin=30, zmax=39)
-    Returns points such as ``10 <= x`` and ``y <= 20`` and ``30 <= z <= zmax``.
 
     """
     if not (x.shape == y.shape == z.shape):
@@ -1814,7 +1831,7 @@ def default_oriented_points(points):
 
     Returns
     -------
-    oriented_points : OrientedPOints
+    oriented_points : OrientedPoints
 
     """
     return OrientedPoints(points, default_orientations(points))

--- a/src/arim/geometry.py
+++ b/src/arim/geometry.py
@@ -1019,7 +1019,7 @@ def spherical_coordinates(x, y, z, r=None):
 
     See Also
     --------
-    Points.spherical_coordinates : corresponding function with the ``Points`` interface.
+    :meth:`Points.spherical_coordinates` : corresponding function with the ``Points`` interface.
 
     """
     if r is None:

--- a/src/arim/geometry.py
+++ b/src/arim/geometry.py
@@ -360,7 +360,7 @@ class Points:
 
         See Also
         --------
-        points_in_rectbox
+        :func:`points_in_rectbox`
 
         """
         return points_in_rectbox(
@@ -491,7 +491,7 @@ class CoordinateSystem:
 
         See Also
         --------
-        convert_to_gcs
+        :func:`convert_to_gcs`
         """
         points = points_gcs.translate(-self.origin)
         # TODO: improve convert_from_gcs
@@ -553,7 +553,7 @@ class CoordinateSystem:
 
         See Also
         --------
-        convert_from_gcs
+        :func:`convert_from_gcs`
         """
         points_cs = points_cs.coords
 

--- a/src/arim/helpers.py
+++ b/src/arim/helpers.py
@@ -67,15 +67,15 @@ def timeit(name="Computation", logger=None, log_level=logging.INFO):
 
     Examples
     --------
-    ::
 
-        >>> with arim.helpers.timeit('Simple addition'):
-        ...     1 + 1
+    >>> with arim.helpers.timeit('Simple addition'):
+    ...     1 + 1
         Simple addition performed in 570.20 ns
 
-    Using a logger::
-        >>> with arim.helpers.timeit('Simple addition', logger=logger):
-        >>>     1 + 1
+    Using a logger:
+
+    >>> with arim.helpers.timeit('Simple addition', logger=logger):
+    ...     1 + 1
 
     """
     default_timer = time.perf_counter
@@ -180,6 +180,7 @@ def get_git_version(short=True):
     """
     Returns the current git revision as a string. Returns an empty string
     if git is not available or if the library is not not in a repository.
+
     """
     curdir = os.getcwd()
     filedir, _ = os.path.split(__file__)
@@ -236,16 +237,8 @@ def get_shape_safely(array, array_name, expected_shape=None):
 
 
 def chunk_array(array_shape, block_size, axis=0):
-    """Yield selectors to split a array into multiple chunk.
-
-        >>> x = np.arange(10)
-        >>> for sel in chunk_array(x.shape, 3):
-        ...     print(x[sel])
-        [0 1 2]
-        [3 4 5]
-        [6 7 8]
-        [9]
-
+    """
+    Yield selectors to split a array into multiple chunk.
 
     Parameters
     ----------
@@ -255,6 +248,17 @@ def chunk_array(array_shape, block_size, axis=0):
         Number of items in each block (except the latest which might have less).
     axis : int, optional
         Split axis. Default: 0
+
+    Examples
+    --------
+
+    >>> x = np.arange(10)
+    >>> for sel in chunk_array(x.shape, 3):
+    ...     print(x[sel])
+    [0 1 2]
+    [3 4 5]
+    [6 7 8]
+    [9]
 
     """
     ndim = len(array_shape)
@@ -276,8 +280,11 @@ def chunk_array(array_shape, block_size, axis=0):
 
 
 def smallest_uint_that_fits(max_value):
-    """Return the smallest unsigned integer datatype (dtype) such as all numbers
-    between 0 and 'max_value' can be stored without overflow."""
+    """
+    Return the smallest unsigned integer datatype (dtype) such as all numbers
+    between 0 and 'max_value' can be stored without overflow.
+
+    """
     dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
     for dtype in dtypes:
         allowed_max_value = np.iinfo(dtype).max

--- a/src/arim/im/das.py
+++ b/src/arim/im/das.py
@@ -39,6 +39,7 @@ import numba
 import numpy as np
 
 from . import geomed, huber
+from ..model import ModelAmplitudes
 
 logger = logging.getLogger(__name__)
 
@@ -937,7 +938,9 @@ def delay_and_sum(frame, focal_law, *args, **kwargs):
     """
     from . import tfm
 
-    if isinstance(focal_law.amplitudes, tfm.TxRxAmplitudes):
+    if isinstance(focal_law.amplitudes, tfm.TxRxAmplitudes) or isinstance(
+        focal_law.amplitudes, ModelAmplitudes
+    ):
         return delay_and_sum_numba(frame, focal_law, *args, **kwargs)
     elif focal_law.amplitudes is None:
         return delay_and_sum_numba_noamp(frame, focal_law, *args, **kwargs)

--- a/src/arim/im/das.py
+++ b/src/arim/im/das.py
@@ -230,6 +230,7 @@ def _delay_and_sum_amplitudes_nearest(
     Returns
     -------
     None
+
     """
     numtimetraces, numsamples = weighted_timetraces.shape
     numpoints, _ = lookup_times_tx.shape
@@ -290,6 +291,7 @@ def _delay_and_sum_amplitudes_linear(
     Returns
     -------
     None
+
     """
     numtimetraces, numsamples = weighted_timetraces.shape
     numpoints, _ = lookup_times_tx.shape
@@ -564,6 +566,7 @@ def _delay_and_sum_noamp_lanczos(
     Delay and sum with Lanczos interpolation with factor 'a' of the timetraces.
 
     https://en.wikipedia.org/wiki/Lanczos_resampling
+
     """
     numtimetraces, numsamples = weighted_timetraces.shape
     numpoints, _ = lookup_times_tx.shape
@@ -708,6 +711,7 @@ def _general_delay_and_sum_nearest(
     Returns
     -------
     None
+
     """
     numtimetraces, numsamples = weighted_timetraces.shape
     numpoints, _ = lookup_times_tx.shape
@@ -770,6 +774,7 @@ def _general_delay_and_sum_linear(
     Returns
     -------
     None
+
     """
     numtimetraces, numsamples = weighted_timetraces.shape
     numpoints, _ = lookup_times_tx.shape
@@ -804,6 +809,7 @@ def delay_and_sum_naive(
     Pure-Python implementation of delay and sum.
 
     This is a very slow implementation, use for test only.
+
     """
     numtimetraces = frame.numtimetraces
     numpoints, _ = focal_law.lookup_times_tx.shape
@@ -881,7 +887,6 @@ def delay_and_sum(frame, focal_law, *args, **kwargs):
     Returns
     -------
     result : ndarray (numpoints, )
-
 
     See Also
     --------

--- a/src/arim/im/geomed.py
+++ b/src/arim/im/geomed.py
@@ -51,6 +51,7 @@ def _gradf_and_inv_hessf(data, z):
         ``invhess[0, 1]``
     a22 : float
         ``invhess[1, 1]``
+
     """
     x = z[0]
     y = z[1]

--- a/src/arim/im/huber.py
+++ b/src/arim/im/huber.py
@@ -51,6 +51,7 @@ def huber_m_estimate(data, tau, xtol=1e-9, maxiter=600):
     -----
     Maronna 2004, chapter "Location and scale": algorithm: (2.75) p 39
     with weights for Huber function: w_tau(x) = min(1, k/abs(x)))  (2.32)
+
     """
     k = 0  # iteration counter
     l1_update = 2 * xtol  # init only

--- a/src/arim/im/huber.py
+++ b/src/arim/im/huber.py
@@ -35,8 +35,6 @@ def huber_m_estimate(data, tau, xtol=1e-9, maxiter=600):
     """
     M-estimate of location using Huber's loss
 
-    Reference:
-
     Parameters
     ----------
     data : (n, 2)
@@ -49,7 +47,7 @@ def huber_m_estimate(data, tau, xtol=1e-9, maxiter=600):
     xsol
     numiter
 
-    Notes
+    Reference
     -----
     Maronna 2004, chapter "Location and scale": algorithm: (2.75) p 39
     with weights for Huber function: w_tau(x) = min(1, k/abs(x)))  (2.32)

--- a/src/arim/im/tfm.py
+++ b/src/arim/im/tfm.py
@@ -267,7 +267,7 @@ class FocalLaw:
             else:
                 # arrays of shape (numgridpoints, numtimetraces)
                 assert amplitudes.ndim == 2
-                assert amplitudes.shape[1] == lookup_times_tx.shape[1]
+                assert amplitudes.shape[0] == lookup_times_tx.shape[0]
                 if numtimetraces is not None:
                     assert amplitudes.shape[1] == numtimetraces
                 else:

--- a/src/arim/im/tfm.py
+++ b/src/arim/im/tfm.py
@@ -329,6 +329,7 @@ class FocalLaw:
         Returns
         -------
         weighted_timetraces : ndarray
+
         """
         assert timetraces.ndim == 2
         if self.timetrace_weights is None:
@@ -409,6 +410,7 @@ class TfmResult:
         Returns
         -------
         intensity : float
+
         """
         if area is None:
             area = slice(None)

--- a/src/arim/io/brain.py
+++ b/src/arim/io/brain.py
@@ -51,6 +51,7 @@ def load_expdata(file):
     Raises
     ------
     InvalidExpData, OSError (HDF5 fail)
+
     """
     try:
         (exp_data, array, filename) = _load_from_scipy(file)
@@ -84,8 +85,15 @@ def load_expdata(file):
 
 def _load_probe(array):
     """
-    :param array: dict-like object corresponding to Matlab struct exp_data.array.
-    :return: Probe
+    Parameters
+    ----------
+    array : dict
+        dict-like object corresponding to Matlab struct exp_data.array.
+
+    Returns
+    -------
+    Probe
+
     """
     frequency = array["centre_freq"][0, 0]
 
@@ -168,10 +176,25 @@ def _load_frame(exp_data, probe):
 
 def _load_from_scipy(file):
     """
+    Parameters
+    ----------
+    file : str or obj
+        Path-like string to a file to be loaded, or a file object.
 
-    :param file:
-    :return:
-    :raises: NotHandledByScipy
+    Returns
+    -------
+        exp_data : dict
+            Dict-like object containing experimental details (tx, rx, time_data, etc.)
+        array : dict
+            Dict-like object containing array details (locations, frequency, etc.)
+        filename : str
+            If `file` is a file object, return the filename.
+
+    Raises
+    ------
+    NotHandledByScipy
+        If file cannot be loaded by scipy (i.e. '-v7.3' tag used in MATLAB.)
+
     """
     import scipy.io as sio
 

--- a/src/arim/io/native.py
+++ b/src/arim/io/native.py
@@ -78,6 +78,7 @@ def load_conf_from_str(stream):
     Returns
     -------
     arim.config.Config
+
     """
     return config.Config(yaml.safe_load(stream))
 
@@ -93,6 +94,7 @@ def load_conf_file(filename):
     Returns
     -------
     arim.config.Config
+
     """
     with open(filename) as f:
         return load_conf_from_str(f)
@@ -117,6 +119,7 @@ def load_conf(dirname, filepath_keys={"filename", "datafile"}):
     Notes
     -----
     Load {dirname}/conf.yaml and all yaml files in {dirname}/conf.d/.
+
     """
     root_dir = pathlib.Path(dirname).resolve(strict=True)
 
@@ -171,7 +174,7 @@ def _resolve_filenames(d, root_dir, target_keys):
 
     Returns
     -------
-    d
+    d : dict
         Updated dictionary
 
     """
@@ -272,11 +275,12 @@ def material_attenuation_from_conf(mat_att_conf):
 
     Returns
     -------
-    func
+    Callable
 
     See Also
     --------
     :func:`arim.core.material_attenuation_factory`
+
     """
     if isinstance(mat_att_conf, float):
         return core.material_attenuation_factory("constant", mat_att_conf)
@@ -304,6 +308,7 @@ def material_from_conf(conf):
     Returns
     -------
     arim.core.Material
+
     """
     material_kwargs = copy.deepcopy(conf)
     material_kwargs["longitudinal_att"] = _material_from_conf(
@@ -431,7 +436,6 @@ def frame_from_conf(
     Load a Frame.
 
     Current limitation: read only from Brain (relies on :func:`arim.io.brain.load_expdata`).
-
 
     Parameters
     ----------

--- a/src/arim/io/scat.py
+++ b/src/arim/io/scat.py
@@ -20,7 +20,6 @@ def load_scat(filename, format="auto"):
     -------
     arim.scat.ScatFromData
 
-
     """
     formats = ["matlab"]
 

--- a/src/arim/measurement.py
+++ b/src/arim/measurement.py
@@ -59,6 +59,7 @@ def find_probe_loc_from_frontwall(frame, couplant, tmin=None, tmax=None):
     --------
     - :func:`detect_surface_from_extrema`
     - :func:`move_probe_over_flat_surface`
+
     """
     frame.probe.reset_position()
 

--- a/src/arim/model.py
+++ b/src/arim/model.py
@@ -1472,6 +1472,10 @@ class ModelAmplitudes(abc.ABC):
         # wrapper in general case, inherit and write a faster implementation if possible
         return sensitivity_model_assisted_tfm(self, timetrace_weights, **kwargs)
 
+    def to_tfm_amplitudes(self, grid_slice=slice(None)):
+        """Prepare model amplitudes for use as amplitudes in TFM function."""
+        return self[grid_slice].conj() / (self[grid_slice].conj()) * self[grid_slice]
+
 
 class _ModelAmplitudesWithScatFunction(ModelAmplitudes):
     def __init__(

--- a/src/arim/model.py
+++ b/src/arim/model.py
@@ -430,7 +430,6 @@ def fluid_solid(
     ----------
     [KK]_
 
-
     """
     alpha_fluid = np.asarray(alpha_fluid)
 
@@ -522,7 +521,6 @@ def solid_l_fluid(
     References
     ----------
     [KK]_
-
 
     """
     if alpha_fluid is None:
@@ -1234,8 +1232,6 @@ def material_attenuation_for_path(path, ray_geometry, frequency):
 
     If no attenuation is provided, ignore silently.
 
-    Reference: Schmerr chapter 9
-
     Parameters
     ----------
     path : Path
@@ -1245,6 +1241,11 @@ def material_attenuation_for_path(path, ray_geometry, frequency):
     -------
     attenuation : ndarray
         Shape: (numelements, numgridpoints)
+
+    References
+    ----------
+    [Schmerr]_ chapter 9
+
     """
     log_att = np.zeros(
         (path.interfaces[0].points.numpoints, path.interfaces[-1].points.numpoints)

--- a/src/arim/model.py
+++ b/src/arim/model.py
@@ -1460,6 +1460,10 @@ class ModelAmplitudes(abc.ABC):
     def shape(self):
         return (self.numpoints, self.numtimetraces)
 
+    @property
+    def ndim(self):
+        return len(self.shape)
+
     def sensitivity_uniform_tfm(self, timetrace_weights, **kwargs):
         # wrapper in general case, inherit and write a faster implementation if possible
         return sensitivity_uniform_tfm(self, timetrace_weights, **kwargs)

--- a/src/arim/model.py
+++ b/src/arim/model.py
@@ -162,6 +162,7 @@ def make_toneburst2(
     See Also
     --------
     :func:`make_toneburst`
+
     """
 
     signal = make_toneburst(
@@ -258,6 +259,7 @@ def directivity_2d_rectangular_in_fluid_for_path(
     -------
     directivity : ndarray
         Signed directivity for each angle.
+
     """
     return directivity_2d_rectangular_in_fluid(
         ray_geometry.conventional_out_angle(0), element_width, wavelength
@@ -381,6 +383,7 @@ def snell_angles(incidents_angles, c_incident, c_refracted):
     If the incident angle is real, the refracted angle is "not a number".
     If the incident angle is complex, the refracted angle is complex (imagery part not null).
     The reason is that either the real or the complex arcsine function is used.
+
     """
     return np.arcsin(c_refracted / c_incident * sin(incidents_angles))
 
@@ -464,9 +467,7 @@ def fluid_solid(
 def _fluid_solid_n(
     alpha_fluid, alpha_l, alpha_t, rho_fluid, rho_solid, c_fluid, c_l, c_t
 ):
-    """
-    Coefficient N defined by Krautkrämer in equation (A8).
-    """
+    """Coefficient N defined by Krautkrämer in equation (A8)."""
     ct_cl2 = (c_t * c_t) / (c_l * c_l)
     cos_2_alpha_t = cos(2 * alpha_t)
     N = (
@@ -1305,6 +1306,7 @@ class RayWeights(
         See function rx_ray_weights
     scattering_angles_dict : dict[arim.Path, ndarray]
         Each value has a shape of (numelements, numgridpoints)
+
     """
 
     @property
@@ -1359,8 +1361,10 @@ def model_amplitudes_factory(tx, rx, view, ray_weights, scattering, scat_angle=0
     >>> model_amplitudes = model_amplitudes_factory(tx, rx, view, ray_weights, scattering)
     >>> model_amplitudes[0]
     # returns the 'numtimetraces' amplitudes at the grid point 0
+
     >>> model_amplitudes[:10] # returns the amplitudes for the first 10 grid points
     array([ 0.27764253,  0.78863332,  0.83998295,  0.96811351,  0.57929045, 0.00935137,  0.8905348 ,  0.46976061,  0.08101099,  0.57615469])
+
     >>> model_amplitudes[...] # returns the amplitudes for all points. Warning: you may
     ... # run out of memory!
     array([...])
@@ -1438,28 +1442,35 @@ class ModelAmplitudes(abc.ABC):
     >>> model_amplitudes = model_amplitudes_factory(tx, rx, view, ray_weights, scattering_dict)
 
     This object is not an array:
+
     >>> type(model_amplitudes)
     __main__.ModelAmplitudes
 
     But when indexed, it returns an array:
+
     >>> type(model_amplitudes[0])
     numpy.ndarray
 
     Get the P_ij for the first grid point (returns an array of size (numtimetraces,)):
+
     >>> model_amplitudes[0]
 
     Get the P_ij for the first ten grid points (returns an array of size
     (10, numtimetraces,)):
+
     >>> model_amplitudes[:10]
 
     Get all P_ij (may run out of memory):
+
     >>> model_amplitudes[...]
 
     To get the first Get all P_ij (may run out of memory):
+
     >>> model_amplitudes[...]
 
     Indexing the second dimension will fail. For example to model amplitude of
     the fourth point and the eigth timetrace, use:
+
     >>> model_amplitudes[3][7]  # valid usage
     >>> model_amplitudes[3, 7]  # invalid usage, raise an IndexError
     """
@@ -1626,6 +1637,7 @@ def sensitivity_uniform_tfm(model_amplitudes, timetrace_weights, block_size=4000
     -------
     predicted_intensities
         Shape: (numpoints, )
+
     """
     numpoints, numtimetraces = model_amplitudes.shape
     assert timetrace_weights.ndim == 1
@@ -1664,6 +1676,7 @@ def sensitivity_model_assisted_tfm(
     -------
     predicted_intensities
         Shape: (numpoints, ).
+
     """
     numpoints, numtimetraces = model_amplitudes.shape
     assert timetrace_weights.ndim == 1

--- a/src/arim/model.py
+++ b/src/arim/model.py
@@ -224,9 +224,7 @@ def directivity_2d_rectangular_in_fluid(theta, element_width, wavelength):
 
     References
     ----------
-
-    Wooh, Shi-Chang, and Yijun Shi. 1999. ‘Three-Dimensional Beam Directivity of Phase-Steered Ultrasound’.
-        The Journal of the Acoustical Society of America 105 (6): 3275–82. doi:10.1121/1.424655.
+    [Wooh]_
 
     See Also
     --------
@@ -297,9 +295,9 @@ def directivity_2d_rectangular_on_solid_l(
 
     Notes
     -----
-    Equations MP (93) and DW (2), (3), (6)
+    Equations Miller (93) and Drinkwater (2), (3), (6)
 
-    The sinc results of the integration of MP (90) with far field
+    The sinc results of the integration of Miller (90) with far field
     approximation.
 
     Normalisation coefficients are ignored, but the values are consistent with
@@ -307,15 +305,7 @@ def directivity_2d_rectangular_on_solid_l(
 
     References
     ----------
-    Miller, G. F., and H. Pursey. 1954. ‘The Field and Radiation Impedance of
-    Mechanical Radiators on the Free Surface of a Semi-Infinite Isotropic
-    Solid’. Proceedings of the Royal Society of London A: Mathematical,
-    Physical and Engineering Sciences 223 (1155): 521–41.
-    https://doi.org/10.1098/rspa.1954.0134.
-
-    Drinkwater, Bruce W., and Paul D. Wilcox. 2006. ‘Ultrasonic Arrays for
-    Non-Destructive Evaluation: A Review’. NDT & E International 39 (7):
-    525–41. https://doi.org/10.1016/j.ndteint.2006.03.006.
+    [Drinkwater]_, [Miller]_
 
     See Also
     --------
@@ -357,7 +347,11 @@ def directivity_2d_rectangular_on_solid_t(
 
     Notes
     -----
-    Equations MP (94) and DW (2), (4), (6)
+    Equations Miller (94) and Drinkwater (2), (4), (6)
+
+    References
+    ----------
+    [Drinkwater]_, [Miller]_
 
     See Also
     --------
@@ -691,6 +685,10 @@ def transmission_at_interface(
     amps : ndarray
         ``amps[i, j]`` is the transmission coefficient for the ray (i, j) at the given interface.
 
+    References
+    ----------
+    [KK]_
+
     """
     if force_complex:
         angles_inc = np.asarray(angles_inc, dtype=complex)
@@ -828,6 +826,10 @@ def reflection_at_interface(
     amps : ndarray
         ``amps[i, j]`` is the reflection coefficient for the ray (i, j) at the given interface.
 
+    References
+    ----------
+    [KK]_
+
     """
     if force_complex:
         angles_inc = np.asarray(angles_inc, dtype=complex)
@@ -945,6 +947,11 @@ def transmission_reflection_for_path(
     ------
     amps : ndarray or None
         Amplitudes of transmission-reflection coefficients. None if not defined for all interface.
+
+    References
+    ----------
+    [KK]_
+
     """
     # Requires the incoming angles for all interfaces except the probe and the scatterers
     # (first and last).
@@ -1009,6 +1016,10 @@ def reverse_transmission_reflection_for_path(
     -------
     rev_transrefl : ndarray
         Shape: (path.interfaces[0].numpoints, path.interfaces[-1].numpoints)
+
+    References
+    ----------
+    [KK]_
 
     """
     transrefl = None
@@ -1104,7 +1115,7 @@ def beamspread_2d_for_path(ray_geometry):
 
     References
     ----------
-    Schmerr, Fundamentals of ultrasonic phased arrays (Springer), §2.5
+    [SchmerrArrays]_, §2.5
 
     """
     velocities = ray_geometry.rays.fermat_path.velocities
@@ -1472,8 +1483,11 @@ class ModelAmplitudes(abc.ABC):
         # wrapper in general case, inherit and write a faster implementation if possible
         return sensitivity_model_assisted_tfm(self, timetrace_weights, **kwargs)
 
-    def to_tfm_amplitudes(self, grid_slice=slice(None)):
-        """Prepare model amplitudes for use as amplitudes in TFM function."""
+    def to_matched_filter_amplitudes(self, grid_slice=slice(None)):
+        """
+        Prepare model amplitudes for use as a matched filter weighting in TFM function
+        as amplitudes [Turin]_.
+        """
         return self[grid_slice].conj() / (self[grid_slice].conj() * self[grid_slice])
 
 

--- a/src/arim/model.py
+++ b/src/arim/model.py
@@ -1474,7 +1474,7 @@ class ModelAmplitudes(abc.ABC):
 
     def to_tfm_amplitudes(self, grid_slice=slice(None)):
         """Prepare model amplitudes for use as amplitudes in TFM function."""
-        return self[grid_slice].conj() / (self[grid_slice].conj()) * self[grid_slice]
+        return self[grid_slice].conj() / (self[grid_slice].conj() * self[grid_slice])
 
 
 class _ModelAmplitudesWithScatFunction(ModelAmplitudes):

--- a/src/arim/models/block_in_contact.py
+++ b/src/arim/models/block_in_contact.py
@@ -104,6 +104,7 @@ def tx_ray_weights(
         Shape (numelements, numgridpoints)
     weights_dict : dict[str, ndarray]
         Components of the ray weights: beamspread, directivity, transmission-reflection, attenuation
+
     """
     d = _init_ray_weights(path, frequency, probe_element_width, use_directivity)
 
@@ -194,6 +195,7 @@ def rx_ray_weights(
         Shape (numelements, numgridpoints)
     weights_dict : dict[str, ndarray]
         Components of the ray weights: beamspread, directivity, transmission-reflection, attenuation
+
     """
     d = _init_ray_weights(path, frequency, probe_element_width, use_directivity)
 
@@ -450,8 +452,9 @@ def make_interfaces(
 
     Returns
     -------
-    interface_dict : dict[Interface]
+    interface_dict : dict[str, Interface]
         Keys: probe, grid, wall_name_1 (optional), ...
+
     """
     interface_dict = OrderedDict()
 
@@ -653,6 +656,7 @@ def ray_weights_for_views(
     Returns
     -------
     RayWeights
+
     """
     tx_ray_weights_dict = {}
     rx_ray_weights_dict = {}
@@ -875,7 +879,8 @@ def wall_unshifted_transfer_functions(
     turn_off_invalid_rays=False,
     walls=None,
 ):
-    """Compute unshifted transfer functions for walls echoes.
+    """
+    Compute unshifted transfer functions for walls echoes.
 
     Output spectra uses the *math* Fourier convention (not the acoustics one).
 
@@ -906,6 +911,7 @@ def wall_unshifted_transfer_functions(
         Shape: (numtimetraces, numfreq). Complex. Contribution for one wall path.
     delays : ndarray
         Shape: (numtimetraces). Float. Contribution for wall path.
+
     """
     freq_array = np.atleast_1d(freq_array)
     numfreq = len(freq_array)
@@ -1001,6 +1007,7 @@ def singlefreq_scat_transfer_functions(
     -----
     Legacy function, superseeded by :func:`scat_unshifted_transfer_functions`
     and :func:`arim.signal.timeshift_spectra`.
+
     """
     unshifted_tfs = scat_unshifted_transfer_functions(
         views,
@@ -1150,6 +1157,7 @@ def multifreq_scat_transfer_functions(
     -----
     Legacy function, superseeded by :func:`scat_unshifted_transfer_functions`
     and :func:`arim.signal.timeshift_spectra`.
+
     """
     unshifted_tfs = scat_unshifted_transfer_functions(
         views,
@@ -1223,6 +1231,7 @@ def multifreq_wall_transfer_functions(
     -----
     Legacy function, superseeded by :func:`wall_unshifted_transfer_functions`
     and :func:`arim.signal.timeshift_spectra`.
+
     """
     unshifted_tfs = wall_unshifted_transfer_functions(
         wall_paths,

--- a/src/arim/models/block_in_immersion.py
+++ b/src/arim/models/block_in_immersion.py
@@ -140,6 +140,7 @@ def tx_ray_weights(
         Shape (numelements, numgridpoints)
     weights_dict : dict[str, ndarray]
         Components of the ray weights: beamspread, directivity, transmission-reflection, attenuation
+
     """
     d = _init_ray_weights(path, frequency, probe_element_width, use_directivity)
 
@@ -223,6 +224,7 @@ def rx_ray_weights(
         Shape (numelements, numgridpoints)
     weights_dict : dict[str, ndarray]
         Components of the ray weights: beamspread, directivity, transmission-reflection, attenuation
+
     """
     d = _init_ray_weights(path, frequency, probe_element_width, use_directivity)
 
@@ -306,6 +308,7 @@ def ray_weights_for_views(
     Returns
     -------
     RayWeights
+
     """
     tx_ray_weights_dict = {}
     rx_ray_weights_dict = {}
@@ -441,7 +444,6 @@ def backwall_paths(
             -> block (L or T) -> backwall -> block (L or T) -> frontwall
             -> block (L or T) -> backwall -> block (L or T) -> frontwall -> couplant -> probe
 
-
     Parameters
     ----------
     couplant_material : Material
@@ -451,7 +453,6 @@ def backwall_paths(
     backwall: OrientedPoints
     max_number_of_reflection : int
         Number of internal reflections. Default: 1.
-
 
     Returns
     -------
@@ -760,6 +761,7 @@ def make_interfaces(
     -------
     interface_dict : dict[Interface]
         Keys: probe, frontwall_trans, grid, wall_name_1 (optional), ...
+
     """
     interface_dict = OrderedDict()
     interface_dict["probe"] = c.Interface(
@@ -815,7 +817,6 @@ def make_paths(
     interface_dict : dict[Interface]
     max_number_of_reflection : int
         Default: 1.
-
 
     Returns
     -------
@@ -1125,6 +1126,7 @@ def wall_unshifted_transfer_functions(
         Shape: (numtimetraces, numfreq). Complex. Contribution for one wall path.
     delays : ndarray
         Shape: (numtimetraces). Float. Contribution for wall path.
+
     """
     freq_array = np.atleast_1d(freq_array)
     numfreq = len(freq_array)
@@ -1220,6 +1222,7 @@ def singlefreq_scat_transfer_functions(
     -----
     Legacy function, superseeded by :func:`scat_unshifted_transfer_functions`
     and :func:`arim.signal.timeshift_spectra`.
+
     """
     unshifted_tfs = scat_unshifted_transfer_functions(
         views,
@@ -1369,6 +1372,7 @@ def multifreq_scat_transfer_functions(
     -----
     Legacy function, superseeded by :func:`scat_unshifted_transfer_functions`
     and :func:`arim.signal.timeshift_spectra`.
+
     """
     unshifted_tfs = scat_unshifted_transfer_functions(
         views,
@@ -1442,6 +1446,7 @@ def multifreq_wall_transfer_functions(
     -----
     Legacy function, superseeded by :func:`wall_unshifted_transfer_functions`
     and :func:`arim.signal.timeshift_spectra`.
+
     """
     unshifted_tfs = wall_unshifted_transfer_functions(
         wall_paths,

--- a/src/arim/plot.py
+++ b/src/arim/plot.py
@@ -92,7 +92,8 @@ def plot_bscan(
     savefig=None,
     filename="bscan",
 ):
-    """Plot Bscan (timetraces vs time)
+    """
+    Plot Bscan (timetraces vs time)
 
     Parameters
     ----------
@@ -100,7 +101,7 @@ def plot_bscan(
     timetraces_idx : slice or tuple or ndarray
         timetraces to use. Any valid numpy array is accepted.
     use_dB : bool, optional
-    ax : matplotlib axis, optional
+    ax : matplotlib.axes.Axes, optional
         Where to draw. Default: create a new figure and axis.
     title : str, optional
         Title of the image (default: "Bscan")
@@ -117,8 +118,8 @@ def plot_bscan(
 
     Returns
     -------
-    ax : matplotlib axis
-    im : matplotlib image
+    ax : matplotlib.axes.Axes
+    im : matplotlib.image.AxesImage
 
     Examples
     --------
@@ -198,18 +199,19 @@ def plot_bscan_pulse_echo(
 
     Parameters
     ----------
-    frame
-    use_dB
-    ax
-    title
-    clim
-    interpolation
-    draw_cbar
-    cmap
+    frame : Frame
+    use_dB : bool
+    ax : matplotlib.axes.Axes, optional
+    title : str
+    clim : tuple, optional
+    interpolation : str, optional
+    draw_cbar : bool
+    cmap : str, optional
 
     Returns
     -------
-    axis, image
+    axis : matplotlib.axes.Axes
+    image : matplotlib.image.AxesImage
 
     See Also
     --------
@@ -283,7 +285,7 @@ def plot_psd(
     Returns
     -------
     ax : matplotlib.axes.Axes
-    lines : dict
+    lines : dict[str, matplotlib.lines.Line2D]
 
     """
     if ax is None:
@@ -394,18 +396,16 @@ def plot_oxz(
 
     Returns
     -------
-    axis
-    image
+    matplotlib.axes.Axes
+    matplotlib.image.AxesImage
 
     Examples
     --------
-    ::
 
-        grid = arim.geometry.Grid(-5e-3, 5e-3, 0, 0, 0, 15e-3, .1e-3)
-        k = 2 * np.pi / 10e-3
-        data = (np.cos(grid.x * 2 * k) * np.sin(grid.z * k))
-        ax, im = aplt.plot_oxz(data, grid)
-
+    >>> grid = arim.geometry.Grid(-5e-3, 5e-3, 0, 0, 0, 15e-3, .1e-3)
+    >>> k = 2 * np.pi / 10e-3
+    >>> data = (np.cos(grid.x * 2 * k) * np.sin(grid.z * k))
+    >>> ax, im = aplt.plot_oxz(data, grid)
 
     """
     if figsize is None:
@@ -507,35 +507,40 @@ def plot_oxz_many(
 
     Parameters
     ----------
-    data_list : List[ndarray]
+    data_list : list[ndarray]
         Data are plotted from top left to bottom right, row per row.
     grid : Grid
     nrows : int
     ncols : int
-    title_list : List[str] or None
+    title_list : list[str] or None
     suptitle : str or None
-    draw_colorbar : boolean
+    draw_colorbar : bool
         Default: True
-    figsize : List[Float] or None
+    figsize : list[float] or None
         Default: ``conf['plot_oxz_many.figsize']``
-    savefig: boolean
+    savefig: bool, optional
         Default: ``conf['savefig']``
-    clim :
-        Color limit. Common for all plots.
-    filename
+    clim : tuple, optional
+        Color limits. Common for all plots.
+    filename : str, optional
+        Name used for saving the image.
     y_title : float
         Adjust y location of the titles.
     y_suptitle : float
         Adjust y location of the titles.
     axes_pad : float
         Pad between images in inches
-
     plot_oxz_kwargs
+        Keyword arguments passed to :func:`plot_oxz`
 
     Returns
     -------
     axes_grid : axes_grid1.ImageGrid
     im_list
+
+    See Also
+    --------
+    :func:`plot_oxz`
 
     """
     if savefig is None:
@@ -612,8 +617,8 @@ def plot_tfm(tfm, y=0.0, func_res=None, interpolation="bilinear", **plot_oxz_kwa
 
     Returns
     -------
-    ax
-    image
+    matplotlib.axes.Axes
+    matplotlib.image.AxesImage
 
     See Also
     --------
@@ -638,13 +643,14 @@ def plot_directivity_finite_width_2d(element_width, wavelength, ax=None, **kwarg
 
     Parameters
     ----------
-    element_width
-    wavelength
+    element_width : float
+    wavelength : float
     ax : matplotlib.axes._subplots.AxesSubplot
     kwargs
 
     Returns
     -------
+    matplotlib.axes.Axes
 
     """
     if ax is None:
@@ -909,11 +915,11 @@ def common_dynamic_db_scale(data_list, area=None, db_range=40.0, ref_db=None):
     Examples
     --------
 
-        >>> area = grid.points_in_rectbox(xmin=10, xmax=20)
-        >>> common_db_scale_iter = common_dynamic_db_scale(data_list, area)
-        >>> for data in data_list:
-        ...     ref_db, clim = next(common_db_scale_iter)
-        ...     plot_oxz(data, grid, scale='db', ref_db=ref_db, clim=clim)
+    >>> area = grid.points_in_rectbox(xmin=10, xmax=20)
+    >>> common_db_scale_iter = common_dynamic_db_scale(data_list, area)
+    >>> for data in data_list:
+    ...     ref_db, clim = next(common_db_scale_iter)
+    ...     plot_oxz(data, grid, scale='db', ref_db=ref_db, clim=clim)
 
     """
     data_max_list = []

--- a/src/arim/ray.py
+++ b/src/arim/ray.py
@@ -35,18 +35,18 @@ def find_minimum_times(
 
     Parameters
     ----------
-    time_1
+    time_1 : ndarray
         Shape: (n, m)
-    time_2
+    time_2 : ndarray
         Shape: (m, p)
     dtype
     dtype_indices
 
     Returns
     -------
-    out_min_times
+    out_min_times : ndarray
         Shape: (n, p)
-    out_min_indices
+    out_min_indices : ndarray
         Shape: (n, p)
 
     Notes
@@ -117,10 +117,10 @@ def _find_minimum_times(time_1, time_2, out_min_times, out_best_indices):
     """
     Parameters
     ----------
-    time_1
-    time_2
-    out_min_time
-    out_best_indices
+    time_1 : ndarray
+    time_2 : ndarray
+    out_min_time : ndarray
+    out_best_indices : ndarray
 
     Returns
     -------
@@ -148,7 +148,7 @@ def ray_tracing_for_paths(
 
     Parameters
     ----------
-    paths_list : List[Path]
+    paths_list : list[Path]
     convert_to_fortran_order
 
     Returns
@@ -193,7 +193,7 @@ def ray_tracing(
 
     Parameters
     ----------
-    views : List[View]
+    views : list[View]
 
     Returns
     -------
@@ -228,12 +228,12 @@ def _expand_rays(interior_indices, indices_new_interface, expanded_indices):
 
     Parameters
     ----------
-    interior_indices: *interior* indices of rays going from A(0) to A(d).
-        Shape: (d, n, m)
-    indices_new_interface: indices of the points of interface A(d) that the rays
-    starting from A(0) cross to go to A(d+1).
-        Shape: (n, p)
-    expanded_indices: OUTPUT
+    interior_indices : ndarray
+        *interior* indices of rays going from A(0) to A(d). Shape: (d, n, m)
+    indices_new_interface : ndarray
+        indices of the points of interface A(d) that the rays starting from A(0) cross
+        to go to A(d+1). Shape: (n, p)
+    expanded_indices : ndarray
         Shape (d+1, n, p)
 
     """
@@ -273,11 +273,12 @@ class Rays:
 
     Parameters
     ----------
-    times : ndarray of floats [n x m]
-        Shortest time between first and last set of points.
+    times : ndarray[float]
+        Shortest time between first and last set of points, shape (n, m)
         ``times[i, j]`` is the total travel time for the ray (i, j).
-    indices_interior : ndarray of floats [(d-2) x n x m]
+    indices_interior : ndarray[float]
         Indices of points through which each ray goes, excluding the first and last interfaces.
+        Shape [(d-2) x n x m].
         ``indices[k-1, i, j]`` is the indice point of the ``k`` *interior* interface through which
         the ray (i,j) goes.
 
@@ -399,14 +400,13 @@ class Rays:
 
         Example
         -------
-        ::
 
-            for (d, (x, y, z)) in enumerate(rays.get_coordinates()):
-                # Coordinates at the d-th interface of the ray between ray A(1)[i] and
-                # ray_A(d)[j].
-                x[i, j]
-                y[i, j]
-                z[i, j]
+        >>> for (d, (x, y, z)) in enumerate(rays.get_coordinates()):
+        ...     # Coordinates at the d-th interface of the ray between ray A(1)[i] and
+        ...     # ray_A(d)[j].
+        ...     x[i, j]
+        ...     y[i, j]
+        ...     z[i, j]
 
 
         """
@@ -430,8 +430,9 @@ class Rays:
         """
         Return the coordinates of one ray as ``Point``.
 
-        This function is slow: use ``get_coordinates`` or a variant for treating
+        This function is slow: use :meth:`Rays.get_coordinates` or a variant for treating
         a larger number of rays.
+
         """
         indices = self.indices[:, start_index, end_index]
         num_points_sets = self.fermat_path.num_points_sets
@@ -481,7 +482,6 @@ class Rays:
         Parameters
         ----------
         path_interfaces : list[Interface]
-            .
         walls : list[OrientedPoints]
             All of the walls in the geometry, passed in from ``examination_object.walls``.
 
@@ -637,16 +637,17 @@ class Rays:
 
         Parameters
         ----------
-        interior_indices: *interior* indices of rays going from A(0) to A(d).
-            Shape: (d, n, m)
-        indices_new_interface: indices of the points of interface A(d) that the rays
-        starting from A(0) cross to go to A(d+1).
-            Shape: (n, p)
+        interior_indices : ndarray
+            *interior* indices of rays going from A(0) to A(d). Shape: (d, n, m)
+        indices_new_interface : ndarray
+            indices of the points of interface A(d) that the rays starting from A(0)
+            cross to go to A(d+1). Shape: (n, p)
 
         Returns
         -------
-        expanded_indices
+        expanded_indices : ndarray
             Shape (d+1, n, p)
+
         """
         d, n, m = interior_indices.shape
         n_, p = indices_new_interface.shape
@@ -698,7 +699,10 @@ class FermatPath(tuple):
 
     A FermatPath must starts and ends with Points objects. Speeds (stored as float) and Points must alternate.
 
-    Ex: FermatPath((points_1, speed_1_2, points_2, speed_2_3, points_3))
+    Example
+    -------
+
+    >>> FermatPath((points_1, speed_1_2, points_2, speed_2_3, points_3))
 
     """
 
@@ -822,7 +826,6 @@ class FermatSolver:
     cached_result : dict
         Keys: Path. Values: _FermatSolverResult
 
-
     """
 
     def __init__(self, fermat_paths_set, dtype=None, dtype_indices=None):
@@ -860,6 +863,7 @@ class FermatSolver:
 
         Returns
         -------
+        FermatSolver
 
         """
         paths = set(
@@ -898,8 +902,6 @@ class FermatSolver:
 
         Warning: it is not safe to call this with a Path not passed to __init__
         because of possible overflows.
-
-
 
         Returns
         -------
@@ -946,14 +948,22 @@ class FermatSolver:
         gc.collect()  # force the garbage collector to delete unreferenced objects
 
     def consecutive_times(self, path):
-        """Computes the rays between two consecutive sets of points.
+        """
+        Computes the rays between two consecutive sets of points.
         This is straight forward: each ray is a straight line; ray lengths are
         obtained by taking the Euclidean distances between points.
 
         Cache the distance array in the two directions: points1 to points2,
         points 2 to points1.
 
-        Returns a ``Rays`` object.
+        Parameters
+        ----------
+        path : Path
+
+        Returns
+        -------
+        Rays
+
         """
         points1, speed, points2 = path
 
@@ -1099,6 +1109,7 @@ class RayGeometry:
     @classmethod
     def from_path(cls, path, use_cache=True):
         """
+        Make a RayGeometry object from a Path object.
 
         Parameters
         ----------
@@ -1108,6 +1119,7 @@ class RayGeometry:
 
         Returns
         -------
+        RayGeometry
 
         """
         if path.rays is None:
@@ -1127,7 +1139,7 @@ class RayGeometry:
         """
         Context manager for cleaning intermediate results after execution.
 
-        Example
+        Examples
         -------
 
         >>> ray_geometry = RayGeometry.from_path(path)
@@ -1137,6 +1149,7 @@ class RayGeometry:
         ... # At this stage, the two results are stored in cache and the intermadiate
         ... # results are discarded.
         >>> ray_geometry.inc_angle(1)  # fetch from cache
+
         """
         if not self._use_cache:
             warnings.warn(
@@ -1247,7 +1260,6 @@ class RayGeometry:
         Parameters
         ----------
         interface_idx : int
-
 
         Returns
         -------

--- a/src/arim/scat.py
+++ b/src/arim/scat.py
@@ -46,7 +46,7 @@ SCAT_KEYS = frozenset(("LL", "LT", "TL", "TT"))
 
 
 def make_angles(numpoints):
-    """Return angles for scattering matrices. Linearly spaced vector in [-pi, pi[."""
+    """Return angles for scattering matrices. Linearly spaced vector in `[-pi, pi]`."""
     return np.linspace(-np.pi, np.pi, numpoints, endpoint=False)
 
 
@@ -69,7 +69,7 @@ def interpolate_matrix(scattering_matrix):
 
     Returns
     -------
-    func
+    Callable
 
     """
     assert scattering_matrix.ndim == 2
@@ -92,6 +92,7 @@ def interpolate_matrices(scattering_matrices):
     Returns
     -------
     dict[str, function]
+
     """
     return {key: interpolate_matrix(mat) for key, mat in scattering_matrices.items()}
 
@@ -130,7 +131,6 @@ def sdh_2d_scat(
     The number of factor in the sum is::
 
         maxn = max(min_terms, ceil(term_factor * alpha), ceil(term_factor * beta))
-
 
     Parameters
     ----------
@@ -770,7 +770,10 @@ def _partial_one_scat_key(scat_func, scat_key, *args, **kwargs):
     """
     Returns a dict of functions.
 
-        >>> assert scat_func(x, y, z, to_compute=['LT'])['LT'] == _partial_one_scat_key(scat_func, 'LT', z)(x, y)
+    Example
+    -------
+
+    >>> assert scat_func(x, y, z, to_compute=['LT'])['LT'] == _partial_one_scat_key(scat_func, 'LT', z)(x, y)
 
     """
     # Remark: do not try to replace this by a lambda function, a proper closure is needed
@@ -804,6 +807,7 @@ def scat_factory(kind, material, *args, **kwargs):
 
     Examples
     --------
+
     >>> material = arim.Material(6300., 3120., 2700., 'solid', metadata={'long_name': 'Aluminium'})
 
     Creating the scattering object:
@@ -859,6 +863,7 @@ class Scattering2d(abc.ABC):
 
     Examples
     --------
+
     >>> material = arim.Material(6300., 3120., 2700., 'solid', metadata={'long_name': 'Aluminium'})
     >>> scat_obj = scat_factory('sdh', material, radius=0.5e-3)
 
@@ -874,7 +879,6 @@ class Scattering2d(abc.ABC):
     array of shape (3, ).
 
     >>> result2 = scat_obj(inc_theta, out_theta, frequency, to_compute=['LL'])
-
 
     ``result2`` is a dict which contains the key 'LL'. Use this feature to reduce the amount
     of computation. Depending on how the function is written, other keys may be returned.
@@ -992,7 +996,6 @@ class Scattering2d(abc.ABC):
         numangles : int
         to_compute : set[str]
 
-
         Returns
         -------
         dict[str, ndarray]
@@ -1034,6 +1037,7 @@ class Scattering2dFromFunc(Scattering2d):
       ie any argument but ``inc_theta``, ``out_theta``, ``frequency`` and ``to_compute``.
 
     This class is abstract.
+
     """
 
     _scat_kwargs = None  # placeholder
@@ -1060,6 +1064,7 @@ class SdhScat(Scattering2dFromFunc):
     Scattering for side-drilled hole
 
     This class provides the :class:`Scattering2d` interface for :func:`sdh_2d_scat`.
+
     """
 
     _scat_func = staticmethod(sdh_2d_scat)
@@ -1192,6 +1197,7 @@ class CrackTipScat(Scattering2dFromFunc):
     Crack tip diffraction
 
     Wrapper for :func:`crack_tip_2d`
+
     """
 
     _scat_func = staticmethod(crack_tip_2d)
@@ -1241,7 +1247,6 @@ class ScatFromData(Scattering2d):
     interp_freq_kwargs : dict
         Passed to ``scipy.interpolate.interp1d``.
         Default: ``bounds_error=False, fill_value='extrapolate'``
-
 
     """
 
@@ -1308,8 +1313,8 @@ class ScatFromData(Scattering2d):
 
         Parameters
         ----------
-        frequencies
-        scat_matrix_dict
+        frequencies : ndarray
+        scat_matrix_dict : dict[str, ndarray]
 
         Returns
         -------
@@ -1357,7 +1362,7 @@ class ScatFromData(Scattering2d):
         frequencies : ndarray
             1d
         new_freq : float
-        multi_freq_scat_matrices : dict[str]
+        multi_freq_scat_matrices : dict[str, ndarray]
             Keys: frequencies (1d array), LL, LT, TL, TT
         interp1d_kwargs : kwargs
             Arguments for ``scipy.interpolate.interp1d``

--- a/src/arim/scat.py
+++ b/src/arim/scat.py
@@ -154,20 +154,7 @@ def sdh_2d_scat(
 
     References
     ----------
-    [Lopez-Sanchez] Lopez-Sanchez, Ana L., Hak-Joon Kim, Lester W. Schmerr, and Alexander
-    Sedov. 2005. ‘Measurement Models and Scattering Models for Predicting the Ultrasonic
-    Pulse-Echo Response From Side-Drilled Holes’. Journal of Nondestructive Evaluation 24
-    3): 83–96. doi:10.1007/s10921-005-7658-4.
-
-    [Brind] Brind, R. J., J. D. Achenbach, and J. E. Gubernatis. 1984. ‘High-Frequency
-    Scattering of Elastic Waves from Cylindrical Cavities’. Wave Motion 6 (1):
-    41–60. doi:10.1016/0165-2125(84)90022-2.
-
-    [Zhang] Zhang, Jie, B.W. Drinkwater, and P.D. Wilcox. 2008. ‘Defect Characterization
-    Using an Ultrasonic Array to Measure the Scattering Coefficient Matrix’. IEEE
-    Transactions on Ultrasonics, Ferroelectrics, and Frequency Control 55 (10): 2254–65.
-    doi:10.1109/TUFFC.924.
-
+    [Brind]_, [Lopez-Sanchez]_, [Zhang]_
 
     """
     theta = out_theta - inc_theta
@@ -363,11 +350,7 @@ def crack_2d_scat(
 
     References
     ----------
-    [Glushkov] Glushkov, Evgeny, Natalia Glushkova, Alexander Ekhlakov, and
-    Elena Shapar. 2006. ‘An Analytically Based Computer Model for Surface
-    Measurements in Ultrasonic Crack Detection’. Wave Motion 43 (6): 458–73.
-    doi:10.1016/j.wavemoti.2006.03.002.
-
+    [Glushkov]_
     Unpublished work from Alexander Velichko
 
     """
@@ -552,8 +535,7 @@ def crack_tip_2d(
 
     Notes
     -----
-    [Ogilvy83] Ogilvy, J. A., and J. A. G. Temple. 1983. ‘Diffraction of Elastic Waves by Cracks: Application to
-    Time-of-Flight Inspection’. Ultrasonics 21 (6):259–69. https://doi.org/10.1016/0041-624X(83)90058-6.
+    [Ogilvy83]_
 
     """
     res = dict()

--- a/src/arim/signal.py
+++ b/src/arim/signal.py
@@ -68,6 +68,7 @@ class ComposedFilter(Filter):
     Composed filter.
 
     When called, this filter applies each of its subfilters on the data.
+
     """
 
     def __init__(self, outer_filters, inner_filters):
@@ -90,7 +91,6 @@ class ComposedFilter(Filter):
 
     def __call__(self, arr, **kwargs):
         """
-
         Parameters
         ----------
         arr
@@ -131,8 +131,8 @@ class ButterworthBandpass(Filter):
     cutoff_min, cutoff_max : float
         Cutoff frequencies in Hz.
     time : arim.Time
-        Time object. This filter can be used only on data sampled consistently with the attribute
-    ``time``.
+        Time object. This filter can be used only on data sampled consistently with the
+        attribute ``time``.
 
     """
 

--- a/src/arim/ut.py
+++ b/src/arim/ut.py
@@ -409,10 +409,9 @@ def rayleigh_vel(longitudinal_vel, transverse_vel):
     -------
     rayleigh_vel : float
 
-    Notes
+    References
     -----
-    [Freund98] Freund, L. B.. 1998. `Dynamic Fracture Mechanics`.
-    Cambridge University Press. p. 83. ISBN 978-0521629225.
+    [Freund98]_
 
 
     """

--- a/src/arim/ut.py
+++ b/src/arim/ut.py
@@ -22,10 +22,13 @@ def fmc(numelements):
 
     Returns
     -------
-    tx : ndarray [numelements^2]
+    tx : ndarray
         Transmitter for each timetrace: 0, 0, ..., 1, 1, ...
+        Shape (numelements^2, )
     rx : ndarray
         Receiver for each timetrace: 1, 2, ..., 1, 2, ...
+        Shape (numelements^2, )
+
     """
     numelements = int(numelements)
     elements = np.arange(numelements)
@@ -45,10 +48,13 @@ def hmc(numelements):
 
     Returns
     -------
-    tx : ndarray [numelements^2]
+    tx : ndarray
         Transmitter for each timetrace: 0, 0, 0, ..., 1, 1, 1, ...
+        Shape (numelements^2)
     rx : ndarray
         Receiver for each timetrace: 0, 1, 2, ..., 1, 2, ...
+        Shape (numelements^2)
+
     """
     numelements = int(numelements)
     elements = np.arange(numelements)
@@ -83,6 +89,7 @@ def infer_capture_method(tx, rx):
     Returns
     -------
     capture_method : string
+
     """
     numelements = max(np.max(tx), np.max(rx)) + 1
     assert len(tx) == len(rx)
@@ -186,7 +193,7 @@ def decibel(arr, reference=None, neginf_value=-1000.0, return_reference=False):
 
     Returns
     -------
-    arr_db
+    arr_db : ndarray
         Array in decibel.
     arr_max: float
         Return ``max(abs(arr))``. This value is returned only if return_max is true.
@@ -222,9 +229,10 @@ def decibel(arr, reference=None, neginf_value=-1000.0, return_reference=False):
 
 
 def wrap_phase(phases):
-    """Return a phase in [-pi, pi[
+    """Return a phase in [-pi, pi)
 
     http://stackoverflow.com/questions/15927755/opposite-of-numpy-unwrap
+
     """
     phases = np.asarray(phases)
     return (phases + np.pi) % (2 * np.pi) - np.pi
@@ -232,7 +240,7 @@ def wrap_phase(phases):
 
 def instantaneous_phase_shift(analytic_sig, time_vect, carrier_frequency):
     """
-    For a signal $x(ray) = A * exp(i (2 pi f_0 ray + phi(ray)))$, returns phi(ray) in [-pi, pi[.
+    For a signal $x(ray) = A * exp(i (2 pi f_0 ray + phi(ray)))$, returns phi(ray) in [-pi, pi).
 
     Parameters
     ----------
@@ -385,11 +393,12 @@ def default_viewname_order(tx_rx_tuple):
 
     Parameters
     ----------
-    tx_rx_tuple
+    tx_rx_tuple : tuple
+        Tuple containing two ndarrays.
 
     Returns
     -------
-    order_tuple
+    order_tuple : tuple
 
     """
     tx, rx = tx_rx_tuple
@@ -412,7 +421,6 @@ def rayleigh_vel(longitudinal_vel, transverse_vel):
     References
     -----
     [Freund98]_
-
 
     """
     poisson = (longitudinal_vel**2 - 2 * transverse_vel**2) / (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1417,6 +1417,11 @@ def test_sensitivity_tfm():
             expected /= numtimetraces
             assert np.isclose(sensitivity[k], expected)
 
+        # Sensitivity for matched filter amplitudes
+        sensitivity = amps.to_matched_filter_amplitudes()
+        assert sensitivity.shape == amps.shape
+        assert np.allclose(sensitivity, amps[:].conj() / (amps[:].conj() * amps[:]))
+
 
 def test_directivity_2d_rectangular_in_fluid():
     theta = 0.0
@@ -1893,3 +1898,7 @@ def test_make_toneburst2():
     )
     n = len(toneburst)
     np.testing.assert_allclose(toneburst2[:n], toneburst)
+
+
+if __name__ == "__main__":
+    test_sensitivity_tfm()


### PR DESCRIPTION
Another useful function I've found recently. I was uncertain if this is what was intended by `sensitivity_model_assisted_tfm`, but from its implementation it didn't seem so, as it seems almost the same as `sensitivity_uniform_tfm`. Happy to combine the implementations if it was, however this name is a little more descriptive.

To enable this, I've allowed TFM amplitudes to be an `ndarray` as well as `TxRxAmplitudes`, which always treats the transmit path and receive path independently (i.e. contains two arrays of shape `(numelements, numpoints)`). The matched filter approach above requires dependence between the Tx and Rx paths (i.e. shape `(numelements**2, numpoints)`). One option is to make a new class for this, but I felt that an `ndarray` is a little easier to work with.

Other changes are minor: expanding the bibliography in the docs to reduce docstrings. I haven't necessarily caught them all, but this is a good number of them.

I am intending to make a new release encompassing all the changes since 0.9 soon, as we have a good amount of new features and I think this marks a good point to do this.